### PR TITLE
Cgen FGU fixes

### DIFF
--- a/CONTRIBUITORS
+++ b/CONTRIBUITORS
@@ -1,3 +1,9 @@
+Corun
+	- CreatureGen.lua : onGenerateButtonPressed(), stripString() [BUG]
+
+Moon Wizard
+	- CreatureGen.lua : onGenerateButtonPressed()
+
 Chris B. (BigD3m0n) (Kuthulu)
 	- CreatureGen.lua : parseTactics()
 

--- a/cgen/lua/creaturegen.lua
+++ b/cgen/lua/creaturegen.lua
@@ -15,6 +15,51 @@
 	GNU General Public License for more details.
 ]]--
 
+function onGenerateButtonPressed()
+	local creList, creData, err, errmsg; 
+	local cgen_window = Interface.findWindow("cgen_window","cgen");
+	local cgen_node = cgen_window.getDatabaseNode();
+
+	creData = nil; 
+	if (nil ~= cgen_node) then
+		local nodes = cgen_node.getChildren(); 
+		local inputText = nodes["input"].getValue();
+		if Interface.getVersion() >= 4 then
+			inputText = inputText:gsub("</p><p>", "</p>\r\n<p>");
+		end
+		creData = CreatureGen.genesis(inputText); 
+		cgen_node.createChild('lograw','formattedtext'); 
+		local lnode = cgen_node.getChild('lograw');
+		lnode.setValue(creData['log']); 
+		cgen_node.getChild('log').setValue(''); 
+
+		local logLevel = DB.getValue(cgen_node,'loglevel',''); 
+		CreatureGen.dlog('loglevel on creation is ' .. tostring(logLevel)); 
+		CreatureGenWindow.processLog(tonumber(logLevel)); 
+
+		if creData.creature.error == true then
+			return;
+		end
+		local npclist = DB.findNode('npc');
+		Debug.console(tostring(npclist),self); 
+		if npclist then
+			creList = npclist.createChild();
+		end
+		err, errmsg = pcall(CreatureGen.populate,creList,creData); 
+		if not err then
+			CreatureGen.addError('Error when populating character record: ' .. errmsg); 
+			CreatureGen.sendErrors(); 
+			CreatureGen.sendWarnings(); 
+			creList.delete(); 
+		else
+			local npcWind = Interface.openWindow("npc",creList);
+			local log = CreatureGen.dumpLog(5); 
+			lnode.setValue(log);
+			CreatureGenWindow.processLog(tonumber(logLevel)); 
+		end
+	end
+end
+
 --[[
 	LUA is a pain in the posterior
 ]]--

--- a/cgen/lua/creaturegen.lua
+++ b/cgen/lua/creaturegen.lua
@@ -23,7 +23,7 @@ function onGenerateButtonPressed()
 	creData = nil; 
 	if (nil ~= cgen_node) then
 		local nodes = cgen_node.getChildren(); 
-		local inputText = nodes["input"].getValue();
+		local inputText = nodes["input"].getText();
 		if Interface.getVersion() >= 4 then
 			inputText = inputText:gsub("</p><p>", "</p>\r\n<p>");
 		end
@@ -2282,7 +2282,11 @@ function stripString(data)
 	data = data:gsub('&#151;','--');
 	data = data:gsub('&#150;','-');
 	data = data:gsub('&#215;','x'); 
-	data = data:gsub('&#146;','\''); 
+	data = data:gsub('&#146;','\'');
+	data = data:gsub('&#8211','-');
+	data = data:gsub('&#x2013','-');
+	data = data:gsub('&#x2014','=-');
+	data = data:gsub('&#8217;', '\'')
 
 	-- UTF-8 codes
 	data = data:gsub('\\u2013','-'); 
@@ -2290,6 +2294,10 @@ function stripString(data)
 	data = data:gsub('\\u2019','\''); 
 	data = data:gsub('\\u201d','\"'); 
 	data = data:gsub('\\u201c','\"'); 
+ 
+	-- UTF-8 characters
+	data = data:gsub('—','--');
+	data = data:gsub('–','-');
 
 	return data; 
 end

--- a/cgen/xml/windows/cgen_window.xml
+++ b/cgen/xml/windows/cgen_window.xml
@@ -27,44 +27,7 @@
 					object representing the content parsed -->
 			<script>
 				function onButtonPress()
-					local creList, creData, err, errmsg; 
-					local cgen_window = Interface.findWindow("cgen_window","cgen");
-					local cgen_node = cgen_window.getDatabaseNode();
-
-					creData = nil; 
-					if (nil ~= cgen_node) then
-						local nodes = cgen_node.getChildren(); 
-						creData = CreatureGen.genesis(nodes["input"].getValue()); 
-						cgen_node.createChild('lograw','formattedtext'); 
-						local lnode = cgen_node.getChild('lograw');
-						lnode.setValue(creData['log']); 
-						cgen_node.getChild('log').setValue(''); 
-
-						local logLevel = DB.getValue(cgen_node,'loglevel',''); 
-						CreatureGen.dlog('loglevel on creation is ' .. tostring(logLevel)); 
-						CreatureGenWindow.processLog(tonumber(logLevel)); 
-
-						if creData.creature.error == true then
-							return;
-						end
-						local npclist = DB.findNode('npc');
-						Debug.console(tostring(npclist),self); 
-						if npclist then
-							creList = npclist.createChild();
-						end
-						err, errmsg = pcall(CreatureGen.populate,creList,creData); 
-						if not err then
-							CreatureGen.addError('Error when populating character record: ' .. errmsg); 
-							CreatureGen.sendErrors(); 
-							CreatureGen.sendWarnings(); 
-							creList.delete(); 
-						else
-							local npcWind = Interface.openWindow("npc",creList);
-							local log = CreatureGen.dumpLog(5); 
-							lnode.setValue(log);
-							CreatureGenWindow.processLog(tonumber(logLevel)); 
-						end
-					end
+					CreatureGen.onGenerateButtonPressed();
 				end
 			</script>
 		</button_text_sm>

--- a/extension.xml
+++ b/extension.xml
@@ -35,5 +35,5 @@
 		<includefile source="cgen/xml/strings/scriptres.xml" />
 	</base>
 
-	<announcement text="CreatureGen v1.80 (GPL v3)" font="emotefont" icon="gCGenExtensionIcon" />
+	<announcement text="CreatureGen v1.82 (GPL v3)" font="emotefont" icon="gCGenExtensionIcon" />
 </root>


### PR DESCRIPTION
Integrates changes from this post by Moon Wizard: 
https://www.fantasygrounds.com/forums/showthread.php?34199-CreatureGen-Extension-Import-Stat-blocks-on-the-fly-with-populated-spells&p=469442&viewfull=1#post469442

It should fix:
'No DEFENSE tag found',
Broken dashes encoding appearing when using statblocks from Archives of Nethys,
Spell-lists not being filled with spells.